### PR TITLE
Fixed Deprecation Warning of Mongoose - Error

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const bodyParser = require('body-parser')
 const cors = require('cors')
 
 const mongoose = require('mongoose')
-mongoose.connect(process.env.MLAB_URI || 'mongodb://localhost/exercise-track' )
+mongoose.connect(process.env.MLAB_URI || 'mongodb://localhost/exercise-track', { useMongoClient: true } )
 
 app.use(cors())
 


### PR DESCRIPTION
Fixed `DeprecationWarning: 'open()' is deprecated in mongoose >= 4.11.0, use 'openUri()' instead`
See: https://github.com/Automattic/mongoose/issues/5399
