### PR TITLE
Update version of mogodb and mongoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
 	},
 	"dependencies": {
 		"express": "^4.14.0",
-		"mongoose": "^4.7.2",
-		"mongodb": "^2.2.14",
+		"mongoose": "^5.10.5",
+		"mongodb": "^3.6.2",
 		"body-parser": "^1.15.2",
 		"cors": "^2.8.1",
 		"shortid": "^2.2.6"


### PR DESCRIPTION
Previous versions of mongodb and mongoose were incompatible and we weren't able to use them properly.